### PR TITLE
Nicer safe-select-keys error message if key not found

### DIFF
--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -133,7 +133,9 @@
   [m k]
   (lazy-get
    m k
-   (schema/assert-iae false "Key %s not found in %s" k (mapv key m))))
+   (schema/assert-iae false "Key %s not found in %s" k
+                      (binding [*print-length* 200]
+                        (print-str (mapv key m))))))
 
 (defn safe-get-in
   "Like get-in but throws exception if not found"

--- a/src/plumbing/map.cljx
+++ b/src/plumbing/map.cljx
@@ -14,7 +14,8 @@
   "Like select-keys, but asserts that all keys are present."
   [m ks]
   (doseq [k ks]
-    (assert (contains? m k)))
+    (or (contains? m k)
+        (schema/assert-iae false "Key %s not found in %s" k (mapv key m))))
   (select-keys m ks))
 
 (defn merge-disjoint

--- a/src/plumbing/map.cljx
+++ b/src/plumbing/map.cljx
@@ -13,9 +13,14 @@
 (defn safe-select-keys
   "Like select-keys, but asserts that all keys are present."
   [m ks]
-  (doseq [k ks]
-    (or (contains? m k)
-        (schema/assert-iae false "Key %s not found in %s" k (mapv key m))))
+  (let [missing (remove (partial contains? m) ks)]
+    (schema/assert-iae (empty? missing) "Keys %s not found in %s" (vec missing)
+                       (let [size (count m)]
+                         (if (> size 200)
+                           (print-str
+                            (conj (mapv key (take 200 m))
+                                  (format "... (%s more)" (- size 200))))
+                           (mapv key m)))))
   (select-keys m ks))
 
 (defn merge-disjoint


### PR DESCRIPTION
Made safe-select-keys return same error message as safe-get (ie. include the list of valid keys).