### PR TITLE
Make transient map visible to `for-map` bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
  * **Deprecate** `keywordize-map` in favor of `clojure.walk/keywordize-keys`
  * Fix dependent optional bindings (e.g. (fnk [a {b a}])) broken in 0.5.1
  * Fnks remember their name, and named fnks can be used without a key in `graph/graph` forms (with an implicit key generated from `(keyword (name f))`).
+ * Make internal transient map visible to conditionals in `for-map` bindings
 
 ## 0.5.2
  * Fix broken cycle check in Clojurescript topological sort.

--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -34,8 +34,8 @@
      `(for-map ~(gensym "m") ~seq-exprs ~key-expr ~val-expr))
   ([m-sym seq-exprs key-expr val-expr]
      `(let [m-atom# (atom (transient {}))]
-        (doseq ~seq-exprs
-          (let [~m-sym @m-atom#]
+        (let [~m-sym @m-atom#]
+          (doseq ~seq-exprs
             (reset! m-atom# (assoc! ~m-sym ~key-expr ~val-expr))))
         (persistent! @m-atom#))))
 


### PR DESCRIPTION
Let binding of the transient map in `for-map` seem to be in a wrong place. 

The following fails 

```clojure
(for-map tmap [i (range 2) j (range 3)
               :let [new-key (set [i j])]
               :when (not (tmap new-key))]
         new-key (* i j))
```

with 

```
;; 1. Caused by java.lang.RuntimeException
;; Unable to resolve symbol: tmap in this context
```