### PR TITLE
local scoping for nodes instead of prohibiting shadowing

### DIFF
--- a/src/plumbing/fnk/schema.cljx
+++ b/src/plumbing/fnk/schema.cljx
@@ -235,7 +235,6 @@
   [[i1 o1] :- GraphIOSchemata
    [k [i2 o2]] :- [(s/one s/Keyword "key") (s/one IOSchemata "inner-schemas")]]
   (assert-iae (not (possibly-contains? i1 k)) "Duplicate key output (possibly due to a misordered graph) %s for input %s from input %s" k (s/explain i2) (s/explain i1))
-  (assert-iae (not (possibly-contains? i2 k)) "Node outputs a key %s in its inputs %s" k (s/explain i2))
   (assert-iae (not (possibly-contains? o1 k)) "Node outputs a duplicate key %s given inputs %s" k (s/explain i1))
   (let [[used unused] (split-schema i2 (keys o1))]
     (assert-satisfies-schema used o1)

--- a/test/plumbing/fnk/schema_test.cljx
+++ b/test/plumbing/fnk/schema_test.cljx
@@ -96,10 +96,11 @@
          (fnk-schema/sequence-schemata
           [{:a s/Any} {:c s/Any}]
           [:o2 [{(s/optional-key :b) s/Any :c s/Any} {:o21 s/Any}]])))
-  (is (thrown? RuntimeException
-               (fnk-schema/sequence-schemata
-                [{:a s/Any} {:c s/Any}]
-                [:o2 [{(s/optional-key :b) s/Any :c s/Any :o2 s/Any} {:o21 s/Any}]])))
+  (is (= [{:a s/Any, :o2 s/Any, (s/optional-key :b) s/Any}
+          {:o2 {:o21 s/Any}, :c s/Any}]
+         (fnk-schema/sequence-schemata
+          [{:a s/Any} {:c s/Any}]
+          [:o2 [{(s/optional-key :b) s/Any :c s/Any :o2 s/Any} {:o21 s/Any}]])))
   (is (thrown? RuntimeException
                (fnk-schema/sequence-schemata
                 [{:a s/Any} {:c s/Any :o2 s/Any}]


### PR DESCRIPTION
Previously, if you had a subgraph with a node that was also in a parent graph, graph would error. In this change, we allow subgraphs to have node names that are also in the parent, and when that happens we abide by local scoping rules (i.e. take the value in the local graph instead of the one in the parent graph. the one in the local graph may take the one from the parent though when computing its value). added tests to demonstrate this and make sure it's behaving as intended.